### PR TITLE
feat: Add Docusaurus authors support

### DIFF
--- a/src/FrontMatterConverter.ts
+++ b/src/FrontMatterConverter.ts
@@ -50,6 +50,11 @@ const convert = (frontMatter: FrontMatter) => {
     }`;
   }
 
+  if (fm.authors) {
+    const authorList = fm.authors.split(',').map(author => author.trim());
+    fm.authors = authorList.length > 1 ? `[${authorList.join(', ')}]` : authorList[0];
+  }
+
   // if fm.tags is array
   if (fm.tags) {
     fm.tags = Array.isArray(fm.tags) ? `[${fm.tags.join(', ')}]` : `[${fm.tags}]`;
@@ -147,7 +152,7 @@ function replaceDateFrontMatter(frontMatter: FrontMatter, isEnable: boolean): Fr
   return frontMatter;
 }
 
-export const convertFrontMatter = (input: string) => {
+export const convertFrontMatter = (input: string, authors?: string) => {
   const [frontMatter, body] = parseFrontMatter(input);
   if (Object.keys(frontMatter).length === 0) {
     return input;
@@ -160,6 +165,12 @@ export const convertFrontMatter = (input: string) => {
 
   delete frontMatter['aliases'];
   delete frontMatter['published'];
+
+  if (authors) {
+    delete frontMatter['authors'];
+    delete frontMatter['author'];
+    frontMatter.authors = authors;
+  }
 
   return join(
     convert({ ...frontMatter }),

--- a/src/docusaurus/docusaurus.ts
+++ b/src/docusaurus/docusaurus.ts
@@ -53,6 +53,7 @@ export const convertToDocusaurus = async (plugin: O2Plugin) => {
             convertWikiLink(
               convertFrontMatter(
                 contents,
+                plugin.docusaurus.authors,
               ),
             ),
           ),

--- a/src/docusaurus/settings/DocusaurusSettings.ts
+++ b/src/docusaurus/settings/DocusaurusSettings.ts
@@ -4,6 +4,7 @@ import { DateExtractionPattern } from '../DateExtractionPattern';
 export default class DocusaurusSettings implements O2PluginSettings {
   docusaurusPath: string;
   dateExtractionPattern: string;
+  authors: string;
 
   targetPath(): string {
     return `${this.docusaurusPath}/blog`;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -64,6 +64,21 @@ export class O2SettingTab extends PluginSettingTab {
     });
     this.addDocusaurusPathSetting();
     this.dateExtractionPatternSetting();
+    this.addDocusaurusAuthorsSetting();
+  }
+
+  private addDocusaurusAuthorsSetting() {
+    const docusaurus = this.plugin.docusaurus as DocusaurusSettings;
+    new Setting(this.containerEl)
+      .setName('Docusaurus authors')
+      .setDesc('Enter author(s) for Docusaurus front matter. For multiple authors, separate with commas.')
+      .addText(text => text
+        .setPlaceholder('jmarcey, slorber')
+        .setValue(docusaurus.authors)
+        .onChange(async (value) => {
+          docusaurus.authors = value;
+          await this.plugin.saveSettings();
+        }));
   }
 
   private enableUpdateFrontmatterTimeOnEditSetting() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -71,7 +71,7 @@ export class O2SettingTab extends PluginSettingTab {
     const docusaurus = this.plugin.docusaurus as DocusaurusSettings;
     new Setting(this.containerEl)
       .setName('Docusaurus authors')
-      .setDesc('Enter author(s) for Docusaurus front matter. For multiple authors, separate with commas.')
+      .setDesc('Author(s) for Docusaurus front matter. For multiple authors, separate with commas.')
       .addText(text => text
         .setPlaceholder('jmarcey, slorber')
         .setValue(docusaurus.authors)


### PR DESCRIPTION
- Implement authors handling in FrontMatterConverter
- Add authors field to DocusaurusSettings
- Pass authors to convertFrontMatter in docusaurus.ts
- Add UI setting for Docusaurus authors in settings.ts

This commit adds support for specifying authors in Docusaurus front matter. Users can now set multiple authors in the plugin settings, which will be correctly formatted in the output. Single authors are handled as strings, while multiple authors are formatted as arrays in the front matter.

# Pull Request

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bugfixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
<!-- If this is a PR that resolves the issue, please include the `close` or `resolve` keyword -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
